### PR TITLE
Add mermaid pharo

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The general idea is to have a place to be able to find datastructures.
 + [GraphViz](https://github.com/hernanmd/GraphViz) - Pharo GraphViz binding.
 + [Jun](https://github.com/tomooda/Jun) - A 3D graphics library with chemoinformatics extensions.
 + [MaterialColors](https://github.com/DuneSt/MaterialColors) - Project implementing Material Design recommandations on colors.
++ [MermaidPharo](https://github.com/badetitou/MermaidPharo) - Pharo support for [MermaidJS](https://mermaid.js.org/#/).
 + [PlantUMLPharoGizmo](https://github.com/fuhrmanator/PlantUMLPharoGizmo) - Pharo support for PlantUML.
 + [Roassal3](https://github.com/ObjectProfile/Roassal3) - The agile 2D visualization engine for Pharo version 3. (V2: [Roassal2](https://github.com/ObjectProfile/Roassal3)) 
 + [Sparta](https://github.com/syrel/Sparta) - Sparta is an almost stateless vector graphics API for Pharo that provides bindings to the Moz2D rendering backend. 


### PR DESCRIPTION
Add a reference to the mermaid pharo project that enables one to create [MermaidJS](https://mermaid.js.org/#/) diagram within pharo