### PR TITLE
Add elasticsearch and jira web api initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,5 +343,5 @@ The general idea is to have a place to be able to find datastructures.
 ## Web API clients
 
 - [DiscordSt](https://github.com/JurajKubelka/DiscordSt) - DiscordSt is a client for Discord written in Pharo.
-- [Jira-Pharo-API](https://github.com/Evref-BL/Jira-Pharo-API) - Jira-Pharo-API is a client for [Jira](https://www.atlassian.com/software/jira) written in Pharo.
 - [Elasticsearch-Pharo-API](https://github.com/Evref-BL/Elasticsearch-Pharo-API) - Elasticsearch-Pharo-API is a client for [Elasticsearch](https://www.elastic.co/elasticsearch/) written in Pharo.
+- [Jira-Pharo-API](https://github.com/Evref-BL/Jira-Pharo-API) - Jira-Pharo-API is a client for [Jira](https://www.atlassian.com/software/jira) written in Pharo.

--- a/README.md
+++ b/README.md
@@ -341,4 +341,7 @@ The general idea is to have a place to be able to find datastructures.
 + [Zinc](https://github.com/svenvc/zinc) - HTTP components to deal with HTTP networking in Smalltalk.
 
 ## Web API clients
+
 - [DiscordSt](https://github.com/JurajKubelka/DiscordSt) - DiscordSt is a client for Discord written in Pharo.
+- [Jira-Pharo-API](https://github.com/Evref-BL/Jira-Pharo-API) - Jira-Pharo-API is a client for [Jira](https://www.atlassian.com/software/jira) written in Pharo.
+- [Elasticsearch-Pharo-API](https://github.com/Evref-BL/Elasticsearch-Pharo-API) - Elasticsearch-Pharo-API is a client for [Elasticsearch](https://www.elastic.co/elasticsearch/) written in Pharo.


### PR DESCRIPTION
Hello

I propose to add the elasticsearch and jira web API initiative. 
Both project are not finish (as lot of project) but they already provide a first structure to manipulate the API of the two projects elasticsearch and jira