### PR TITLE
Add ShellStone to Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ The general idea is to have a place to be able to find datastructures.
 + [Mocketry](https://github.com/dionisiydk/Mocketry) - Mock objects library with very fluent lightweight API.
 + [µ-talk](https://github.com/pavel-krivanek/mutalk) - Mutation Testing in Smalltalk.
 + [ParametrizedTests](https://github.com/tesonep/ParametrizedTests) - Extension to SUnit to implement parametrized tests in Pharo.
++ [ShellStone](https://github.com/tomas-stefano/shellstone) - RSpec-inspired BDD testing framework with matchers, hooks, and test doubles. Cross-platform (GNU Smalltalk & Pharo). **Experimental**.
 + [StateSpecs](https://github.com/dionisiydk/StateSpecs) - Assertions library based on should expressions.
 
 ## Tutorials


### PR DESCRIPTION
## Add ShellStone to Testing section

Hi! I'd like to add [ShellStone](https://github.com/tomas-stefano/shellstone) to the Testing section.

ShellStone is an RSpec-inspired BDD testing framework that works on both GNU Smalltalk and Pharo. It provides:
- Matchers (`equal:`, `beNil`, `include:`, `raiseError`, etc.)
- Nested `describe`/`context` blocks with hooks (`before:`/`after:`)
- Test doubles (mocks and spies)

**I started this project as a way to learn Smalltalk**, so I've marked it as **Experimental**. 

Please let me know if that's appropriate or if you'd prefer a different label (or none at all).

Thank you for maintaining this list!
